### PR TITLE
Loose ends

### DIFF
--- a/config/af.py
+++ b/config/af.py
@@ -14,7 +14,6 @@ FINAL_PUNCTUATION = utils.DEFAULT_FINAL_PUNCTUATION
 
 NUMERALS = byte.DIGIT
 
-
 # Afrikaans <ek> and <het> are often contracted to <'k> and <'t>.
 # This rule expands the contractions to their full forms.
 EMBIGGEN_CONTRACTIONS = cdrewrite(
@@ -28,6 +27,11 @@ LANGUAGE_SPECIFIC_PREPROCESSING = EMBIGGEN_CONTRACTIONS
 
 UD = "language_data/af/UD_Afrikaans-AfriBooms/af_afribooms-ud-train.conllu"
 UM = ""
-AC = ""
-OSCAR = ""
-LCC = ""
+AC = "language_data/af/ac/af-wordbigrams.txt"
+OSCAR = "language_data/af/oscar/af.txt"
+OSCAR_DEDUP = "language_data/af/oscar/af_dedup.txt"
+#LCC = "language_data/af/lcc/afr_mixed_2019_1M/afr_mixed_2019_1M-sentences.txt"
+#LCC = "language_data/af/lcc/afr_mixed_2019_300K/afr_mixed_2019_300K-sentences.txt"
+#LCC = "language_data/af/lcc/afr_mixed_2019_100K/afr_mixed_2019_100K-sentences.txt"
+LCC = "language_data/af/lcc/afr_mixed_2019_30K/afr_mixed_2019_30K-sentences.txt"
+#LCC = "language_data/af/lcc/afr_mixed_2019_1M/afr_mixed_2019_10K-sentences.txt"

--- a/config/af.py
+++ b/config/af.py
@@ -25,6 +25,8 @@ EMBIGGEN_CONTRACTIONS = cdrewrite(
 
 LANGUAGE_SPECIFIC_PREPROCESSING = EMBIGGEN_CONTRACTIONS
 
+# These files are not in the repo. You will need to change these paths to match
+# where you place the data files.
 UD = "language_data/af/UD_Afrikaans-AfriBooms/af_afribooms-ud-train.conllu"
 UM = ""
 AC = "language_data/af/ac/af-wordbigrams.txt"

--- a/config/am.py
+++ b/config/am.py
@@ -122,8 +122,9 @@ REDUCE_OVERDIFFERENTIATION = cdrewrite(
 
 LANGUAGE_SPECIFIC_PREPROCESSING = REDUCE_OVERDIFFERENTIATION
 
-UD = ""
+UD = "language_data/am/UD_Amharic-ATT/am_att-ud-test.conllu"
 UM = ""
-AC = ""
-OSCAR = ""
-LCC = ""
+AC = "language_data/am/ac/am-wordbigrams.txt"
+OSCAR = "language_data/am/oscar/am.txt"
+OSCAR_DEDUP = "language_data/am/oscar/am_dedup.txt"
+LCC = "language_data/am/lcc/amh_wikipedia_2016_30K/amh_wikipedia_2016_30K-sentences.txt"

--- a/config/am.py
+++ b/config/am.py
@@ -122,6 +122,8 @@ REDUCE_OVERDIFFERENTIATION = cdrewrite(
 
 LANGUAGE_SPECIFIC_PREPROCESSING = REDUCE_OVERDIFFERENTIATION
 
+# These files are not in the repo. You will need to change these paths to match
+# where you place the data files.
 UD = "language_data/am/UD_Amharic-ATT/am_att-ud-test.conllu"
 UM = ""
 AC = "language_data/am/ac/am-wordbigrams.txt"

--- a/config/bm_latn.py
+++ b/config/bm_latn.py
@@ -15,6 +15,8 @@ FINAL_PUNCTUATION = utils.DEFAULT_FINAL_PUNCTUATION
 
 NUMERALS = byte.DIGIT
 
+# These files are not in the repo. You will need to change these paths to match
+# where you place the data files.
 UD = "language_data/bm_latn/UD_Bambara-CRB/bm_crb-ud-test.conllu"
 UM = ""
 AC = "language_data/bm_latn/ac/bm-wordbigrams.txt"

--- a/config/bm_latn.py
+++ b/config/bm_latn.py
@@ -15,8 +15,9 @@ FINAL_PUNCTUATION = utils.DEFAULT_FINAL_PUNCTUATION
 
 NUMERALS = byte.DIGIT
 
-UD = ""
+UD = "language_data/bm_latn/UD_Bambara-CRB/bm_crb-ud-test.conllu"
 UM = ""
-AC = ""
-OSCAR = ""
+AC = "language_data/bm_latn/ac/bm-wordbigrams.txt"
+OSCAR = "" # none
+OSCAR_DEDUP = "" # none
 LCC = ""

--- a/config/ha.py
+++ b/config/ha.py
@@ -32,6 +32,8 @@ HOOK_TO_APOSTROPHE_Y = cdrewrite(
 LANGUAGE_SPECIFIC_PREPROCESSING = APOSTROPHE_TO_HOOK_Y
 #LANGUAGE_SPECIFIC_PREPROCESSING = HOOK_TO_APOSTROPHE_Y
 
+# These files are not in the repo. You will need to change these paths to match
+# where you place the data files.
 UD = "" # none
 UM = ""
 AC = "language_data/ha/ac/ha-wordbigrams.txt"

--- a/config/ha.py
+++ b/config/ha.py
@@ -15,11 +15,11 @@ NUMERALS = byte.DIGIT
 
 # Hausa in Niger uses y with right hook. This rule converts modifier letter
 # apostrophe y (used in Nigeria) to the Niger standard.
-#APOSTROPHE_TO_HOOK_Y = cdrewrite(
-#    cross("ʼy", "ƴ"),
-#    "",
-#    "",
-#    byte.BYTES.closure())
+APOSTROPHE_TO_HOOK_Y = cdrewrite(
+    cross("'y", "ƴ"),
+    "",
+    "",
+    byte.BYTES.closure())
 
 # Hausa in Nigeria uses modifier letter apostrophe y. This rule converts y with
 # right hook (used in Niger) to the Nigeria standard.
@@ -29,11 +29,12 @@ HOOK_TO_APOSTROPHE_Y = cdrewrite(
     "",
     byte.BYTES.closure())
 
-#LANGUAGE_SPECIFIC_PREPROCESSING = APOSTROPHE_TO_HOOK_Y
-LANGUAGE_SPECIFIC_PREPROCESSING = HOOK_TO_APOSTROPHE_Y
+LANGUAGE_SPECIFIC_PREPROCESSING = APOSTROPHE_TO_HOOK_Y
+#LANGUAGE_SPECIFIC_PREPROCESSING = HOOK_TO_APOSTROPHE_Y
 
-UD = ""
+UD = "" # none
 UM = ""
-AC = ""
-OSCAR = ""
+AC = "language_data/ha/ac/ha-wordbigrams.txt"
+OSCAR = "" # none
+OSCAR_DEDUP = "" # none
 LCC = ""

--- a/config/ig.py
+++ b/config/ig.py
@@ -38,10 +38,12 @@ FROM_NEW_STANDARD_ALPHABET = cdrewrite(
     "",
     byte.BYTES.closure())
 
+#LANGUAGE_SPECIFIC_PREPROCESSING = TO_NEW_STANDARD_ALPHABET
 LANGUAGE_SPECIFIC_PREPROCESSING = FROM_NEW_STANDARD_ALPHABET
 
-UD = ""
+UD = "" # none
 UM = ""
-AC = ""
-OSCAR = ""
+AC = "language_data/ig/ac/ig-wordbigrams.txt"
+OSCAR = "" # none
+OSCAR_DEDUP = "" # none
 LCC = ""

--- a/config/ig.py
+++ b/config/ig.py
@@ -41,6 +41,8 @@ FROM_NEW_STANDARD_ALPHABET = cdrewrite(
 #LANGUAGE_SPECIFIC_PREPROCESSING = TO_NEW_STANDARD_ALPHABET
 LANGUAGE_SPECIFIC_PREPROCESSING = FROM_NEW_STANDARD_ALPHABET
 
+# These files are not in the repo. You will need to change these paths to match
+# where you place the data files.
 UD = "" # none
 UM = ""
 AC = "language_data/ig/ac/ig-wordbigrams.txt"

--- a/config/mg.py
+++ b/config/mg.py
@@ -35,7 +35,8 @@ LANGUAGE_SPECIFIC_PREPROCESSING = (MG_VELAR_NASAL @ MG_ABBREVIATION).optimize()
 
 UD = ""
 UM = ""
-AC = "language_data/mg/mg_ac/mg-words.txt"
-OSCAR = ""
-LCC = "language_data/mg/mlg_wikipedia_2014_30K/mlg_wikipedia_2014_30K-sentences.txt"
-#LCC = "language_data/mg/mlg_wikipedia_2014_30K/mlg_web_2012_30K-sentences.txt"
+AC = "language_data/mg/ac/mg-wordbigrams.txt"
+OSCAR = "language_data/mg/oscar/mg.txt"
+OSCAR_DEDUP = "language_data/mg/oscar/mg_dedup.txt"
+LCC = "language_data/mg/lcc/mlg_wikipedia_2014_30K/mlg_wikipedia_2014_30K-sentences.txt"
+#LCC = "language_data/mg/lcc/mlg_web_2012_30K/mlg_web_2012_30K-sentences.txt"

--- a/config/mg.py
+++ b/config/mg.py
@@ -33,6 +33,8 @@ MG_ABBREVIATION = cdrewrite(
 
 LANGUAGE_SPECIFIC_PREPROCESSING = (MG_VELAR_NASAL @ MG_ABBREVIATION).optimize()
 
+# These files are not in the repo. You will need to change these paths to match
+# where you place the data files.
 UD = ""
 UM = ""
 AC = "language_data/mg/ac/mg-wordbigrams.txt"

--- a/config/so.py
+++ b/config/so.py
@@ -12,8 +12,10 @@ FINAL_PUNCTUATION = utils.DEFAULT_FINAL_PUNCTUATION
 
 NUMERALS = byte.DIGIT
 
-UD = ""
+UD = "" # none
 UM = ""
-AC = ""
-OSCAR = ""
-LCC = ""
+AC = "language_data/so/ac/so-words.txt"
+OSCAR = "language_data/so/oscar/so.txt"
+OSCAR_DEDUP = "language_data/so/oscar/so_dedup.txt"
+#LCC = "language_data/so/lcc/som_newscrawl_2011_100K/som_newscrawl_2011_100K-sentences.txt"
+LCC = "language_data/so/lcc/som_wikipedia_2016_10K/som_wikipedia_2016_10K-sentences.txt"

--- a/config/so.py
+++ b/config/so.py
@@ -12,6 +12,8 @@ FINAL_PUNCTUATION = utils.DEFAULT_FINAL_PUNCTUATION
 
 NUMERALS = byte.DIGIT
 
+# These files are not in the repo. You will need to change these paths to match
+# where you place the data files.
 UD = "" # none
 UM = ""
 AC = "language_data/so/ac/so-words.txt"

--- a/config/sw.py
+++ b/config/sw.py
@@ -12,8 +12,11 @@ FINAL_PUNCTUATION = utils.DEFAULT_FINAL_PUNCTUATION
 
 NUMERALS = byte.DIGIT
 
-UD = ""
+UD = "" # none
 UM = ""
-AC = ""
-OSCAR = ""
-LCC = ""
+AC = "language_data/sw/ac/sw-words.txt"
+OSCAR = "language_data/sw/oscar/sw.txt"
+OSCAR_DEDUP = "language_data/sw/oscar/sw_dedup.txt"
+#LCC = "language_data/sw/lcc/swa_wikipedia_2016_100K/swa_wikipedia_2016_100K-sentences.txt"
+#LCC = "language_data/sw/lcc/swa_newscrawl_2011_10K/swa_newscrawl_2011_10K-sentences.txt"
+LCC = "language_data/sw/lcc/swh_wikipedia_2011_30K/swh_wikipedia_2011_30K-sentences.txt"

--- a/config/sw.py
+++ b/config/sw.py
@@ -12,6 +12,8 @@ FINAL_PUNCTUATION = utils.DEFAULT_FINAL_PUNCTUATION
 
 NUMERALS = byte.DIGIT
 
+# These files are not in the repo. You will need to change these paths to match
+# where you place the data files.
 UD = "" # none
 UM = ""
 AC = "language_data/sw/ac/sw-words.txt"

--- a/config/wo.py
+++ b/config/wo.py
@@ -18,6 +18,8 @@ FINAL_PUNCTUATION = utils.DEFAULT_FINAL_PUNCTUATION
 
 NUMERALS = byte.DIGIT
 
+# These files are not in the repo. You will need to change these paths to match
+# where you place the data files.
 UD = "language_data/wo/UD_Wolof-WTB/wo_wtb-ud-train.conllu"
 UM = ""
 AC = "language_data/wo/ac/wo-wordbigrams.txt"

--- a/config/wo.py
+++ b/config/wo.py
@@ -18,8 +18,9 @@ FINAL_PUNCTUATION = utils.DEFAULT_FINAL_PUNCTUATION
 
 NUMERALS = byte.DIGIT
 
-UD = ""
+UD = "language_data/wo/UD_Wolof-WTB/wo_wtb-ud-train.conllu"
 UM = ""
-AC = ""
-OSCAR = ""
+AC = "language_data/wo/ac/wo-wordbigrams.txt"
+OSCAR = "" # none
+OSCAR_DEDUP = "" # none
 LCC = ""

--- a/config/yo.py
+++ b/config/yo.py
@@ -22,6 +22,8 @@ FINAL_PUNCTUATION = utils.DEFAULT_FINAL_PUNCTUATION
 
 NUMERALS = byte.DIGIT
 
+# These files are not in the repo. You will need to change these paths to match
+# where you place the data files.
 UD = "language_data/yo/UD_Yoruba-YTB/yo_ytb-ud-test.conllu"
 UM = ""
 AC = "language_data/yo/ac/yo-wordbigrams.txt"

--- a/config/yo.py
+++ b/config/yo.py
@@ -22,8 +22,9 @@ FINAL_PUNCTUATION = utils.DEFAULT_FINAL_PUNCTUATION
 
 NUMERALS = byte.DIGIT
 
-UD = ""
+UD = "language_data/yo/UD_Yoruba-YTB/yo_ytb-ud-test.conllu"
 UM = ""
-AC = ""
-OSCAR = ""
-LCC = ""
+AC = "language_data/yo/ac/yo-wordbigrams.txt"
+OSCAR = "language_data/yo/oscar/yo.txt"
+OSCAR_DEDUP = "language_data/yo/oscar/yo_dedup.txt"
+LCC = "language_data/yo/lcc/yor_wikipedia_2016_10K/yor_wikipedia_2016_10K-sentences.txt"

--- a/config/zu.py
+++ b/config/zu.py
@@ -45,6 +45,8 @@ REMOVE_HYPHEN_AFTER_NOUN_CLASSIFIER = cdrewrite(
 
 LANGUAGE_SPECIFIC_PREPROCESSING = REMOVE_HYPHEN_AFTER_NOUN_CLASSIFIER
 
+# These files are not in the repo. You will need to change these paths to match
+# where you place the data files.
 UD = "" # none
 UM = "language_data/zu/zu_um.txt"
 AC = "language_data/zu/ac/zu-wordbigrams.txt"

--- a/config/zu.py
+++ b/config/zu.py
@@ -45,8 +45,13 @@ REMOVE_HYPHEN_AFTER_NOUN_CLASSIFIER = cdrewrite(
 
 LANGUAGE_SPECIFIC_PREPROCESSING = REMOVE_HYPHEN_AFTER_NOUN_CLASSIFIER
 
-UD = ""
-UM = ""
-AC = ""
-OSCAR = ""
-LCC = ""
+UD = "" # none
+UM = "language_data/zu/zu_um.txt"
+AC = "language_data/zu/ac/zu-wordbigrams.txt"
+OSCAR = "" # none
+OSCAR_DEDUP = "" # none
+#LCC = "language_data/zu/lcc/zul_mixed_2014_100K/zul_mixed_2014_100K-sentences.txt"
+LCC = "language_data/zu/lcc/zul_mixed_2014_30K/zul_mixed_2014_30K-sentences.txt"
+#LCC = "language_data/zu/lcc/zul_news_2013_30K/zul_news_2013_30K-sentences.txt"
+#LCC = "language_data/zu/lcc/zul_web_2013_100K/zul_web_2013_100K-sentences.txt"
+#LCC = "language_data/zu/lcc/zul-za_web_2018_30K/zul-za_web_2018_30K-sentences.txt"

--- a/normalizer_lib.py
+++ b/normalizer_lib.py
@@ -55,14 +55,19 @@ class NormalizerLib:
             union("[BOS]", byte.SPACE),
             union("[EOS]", byte.SPACE),
             self.sigma_star)
-        self.universal_rules = cdrewrite(
+        self.normalize_single_quotation_marks = cdrewrite(
             string_map((("ʼ", "'"), # modifier letter apostrophe
                         ("ʽ", "'"), # inverted comma
                         ("’", "'"), # right single quote
                         ("‘", "'"), # left single quote
                         ("`", "'"), # grave accent
                         ("´", "'"), # acute accent
-                        ("”", "\""),# right double quote
+                        )),
+            "",
+            "",
+            self.sigma_star)
+        self.normalize_double_quotation_marks = cdrewrite(
+            string_map((("”", "\""),# right double quote
                         ("“", "\""),# left double quote
                         ("＂", "\""),# full width quote
                         ("‟", "\"") # double high reversed quote
@@ -70,6 +75,9 @@ class NormalizerLib:
             "",
             "",
             self.sigma_star)
+        self.universal_rules = (self.normalize_single_quotation_marks @
+                                self.normalize_double_quotation_marks
+                                ).optimize()
 
 
     def verbalizable(self) -> Fst:

--- a/normalizer_lib.py
+++ b/normalizer_lib.py
@@ -55,6 +55,21 @@ class NormalizerLib:
             union("[BOS]", byte.SPACE),
             union("[EOS]", byte.SPACE),
             self.sigma_star)
+        self.universal_rules = cdrewrite(
+            string_map((("ʼ", "'"), # modifier letter apostrophe
+                        ("ʽ", "'"), # inverted comma
+                        ("’", "'"), # right single quote
+                        ("‘", "'"), # left single quote
+                        ("`", "'"), # grave accent
+                        ("´", "'"), # acute accent
+                        ("”", "\""),# right double quote
+                        ("“", "\""),# left double quote
+                        ("＂", "\""),# full width quote
+                        ("‟", "\"") # double high reversed quote
+                        )),
+            "",
+            "",
+            self.sigma_star)
 
 
     def verbalizable(self) -> Fst:
@@ -104,7 +119,21 @@ class NormalizerLib:
                           closure(self.numerals, 1, 3) +
                           (union(",", ".") +
                            closure(self.numerals, 1, 4).ques))).optimize()
-        return union(token, email_address, web_address, times, fancy_numbers).optimize()
+
+        valid_sentence = (((token |
+                            email_address |
+                            web_address |
+                            times |
+                            fancy_numbers) +
+                           byte.SPACE).star +
+                          (token |
+                           email_address |
+                           web_address |
+                           times |
+                           fancy_numbers) +
+                          byte.SPACE.star +
+                          self.final_punctuation.star).optimize()
+        return valid_sentence.optimize()
 
 
     def split_into_tokens(self, string) -> List[str]:
@@ -130,14 +159,14 @@ class NormalizerLib:
             The line, where invalid tokens have been replaced with <UNK>.
         """
         returned: List[str] = []
+
         for token in self.split_into_tokens(string):
-            if difference(acceptor(token), self.verbalizable()
-                          ).num_states() == 0:
+            diff = difference(acceptor(token), self.verbalizable())
+            if diff.num_states() == 0:
                 returned.append(token)
             else:
                 returned.append("<UNK>")
         return " ".join(returned)
-
 
     def pass_only_valid_sentences(self, string) -> List[str]:
         """Replaces invalid sentences.
@@ -148,9 +177,8 @@ class NormalizerLib:
         Returns:
             The line or the line replaced with <SENTENCE_REJECTED>.
         """
-        for token in self.split_into_tokens(string):
-            if difference(acceptor(token), self.verbalizable()).num_states() != 0:
-                return "<SENTENCE_REJECTED>"
+        if difference(acceptor(string), self.verbalizable()).num_states() != 0:
+            return "<SENTENCE_REJECTED>"
         return string
 
 
@@ -185,12 +213,13 @@ class NormalizerLib:
 #        strip_accents = self.strip_accents(lowercase_string)
 #        unicode_normalize = unicodedata.normalize("NFC", strip_accents)
         unicode_normalize = unicodedata.normalize("NFC", lowercase_string)
+        universal_rules = (unicode_normalize @ self.universal_rules).optimize().string()
         if normalizer == "sentence":
             filter_string = self.pass_only_valid_sentences(
-                unicode_normalize)
+                universal_rules)
         else:
             filter_string = self.pass_only_valid_tokens(
-                unicode_normalize)
+                universal_rules)
         return filter_string
 
     @staticmethod

--- a/preprocess.py
+++ b/preprocess.py
@@ -123,7 +123,7 @@ def process_ancrubadan_data(ac_file: str) -> List[str]:
     ac_lines = read_file_as_lines(ac_file)
     ac_words: List[str] = []
     for line in ac_lines:
-        text: str = line.split(" ")[0]
+        text: str = " ".join(line.split(" ")[:2])
         word: str = substitute_brackets(text)
         ac_words.append(word)
     return ac_words
@@ -145,9 +145,12 @@ def process_oscar_data(oscar_file: str) -> List[str]:
     """
     oscar_lines = read_file_as_lines(oscar_file)
     oscar_strings: List[str] = []
+#    for line in oscar_lines[:10000]: # limit to 10,000 lines for big data sets
     for line in oscar_lines:
-        sentence: str = substitute_brackets(line)
-        oscar_strings.append(sentence)
+        split_line = re.split(r"\. |።", line)
+        for text in split_line:
+            sentence: str = substitute_brackets(text)
+            oscar_strings.append(sentence)
     return oscar_strings
 
 

--- a/preprocess_test.py
+++ b/preprocess_test.py
@@ -31,7 +31,7 @@ class TestPreprocess(unittest.TestCase):
         'Test loading in an ac data file.'
         infile = "testdata/test_mg_ac_input.txt"
         input_text: List[str] = preprocess.process_data(infile, "ac")
-        expected = "amin'ny"
+        expected = "amin'ny habakabaka"
         self.assertEqual(input_text[0], expected)
 
 

--- a/testdata/test_mg_ac_input.txt
+++ b/testdata/test_mg_ac_input.txt
@@ -1,1 +1,1 @@
-amin'ny 27379
+amin'ny habakabaka 2301


### PR DESCRIPTION
This PR ties up some loose ends with the project that hadn't been merged yet. Specifically, it adds some the changes to
- individual config files, including the paths to the data
- changes to `normalizer_lib.py`, including changes to `self.verbalizable()`, new universal rewrite rules, and some tweaks to how the filtering works
- changes to `preprocess.py` and `preprocess_test.py`, mostly only because we're using the bigrams and not unigrams